### PR TITLE
Add a module not found error instead of assertion error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,20 @@
 'use strict';
-var resolveFrom = require('resolve-from');
+const resolveFrom = require('resolve-from');
+
+function createModuleNotFoundErr(path) {
+	const err = new Error('Cannot find module \'' + path + '\'');
+	err.code = 'MODULE_NOT_FOUND';
+	return err;
+}
 
 module.exports = function (fromDir, moduleId) {
-	return require(resolveFrom(fromDir, moduleId));
+	try {
+		return require(resolveFrom(fromDir, moduleId));
+	} catch (err) {
+		if (err.message === 'missing path') {
+			throw createModuleNotFoundErr(moduleId);
+		}
+	}
 };
 
 module.exports.silent = function (fromDir, moduleId) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "path"
   ],
   "dependencies": {
-    "resolve-from": "^2.0.0"
+    "resolve-from": "^3.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -9,8 +9,6 @@ test('reqFrom', t => {
 	}, Error);
 	t.is(moduleNotFoundError.code, 'MODULE_NOT_FOUND');
 	t.is(moduleNotFoundError.message, 'Cannot find module \'./nonexistent\'');
-	t.is(fn.silent('fixture', './fixture'), 'unicorn');
-	t.is(fn.silent('fixture', './nonexistent'), null);
 });
 
 test('reqFrom,silent', t => {

--- a/test.js
+++ b/test.js
@@ -4,6 +4,11 @@ import fn from './';
 test(t => {
 	t.is(fn('fixture', './fixture'), 'unicorn');
 	t.throws(() => fn('fixture', './nonexistent'));
+	const moduleNotFoundError = t.throws(() => {
+		fn('fixture', './nonexistent');
+	}, Error);
+	t.is(moduleNotFoundError.code, 'MODULE_NOT_FOUND');
+	t.is(moduleNotFoundError.message, 'Cannot find module \'./nonexistent\'');
 	t.is(fn.silent('fixture', './fixture'), 'unicorn');
 	t.is(fn.silent('fixture', './nonexistent'), null);
 });

--- a/test.js
+++ b/test.js
@@ -1,9 +1,10 @@
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test('reqFrom()', t => {
 	t.is(m('fixture', './fixture'), 'unicorn');
 	t.throws(() => m('fixture', './nonexistent'));
+	
 	const moduleNotFoundError = t.throws(() => {
 		m('fixture', './nonexistent');
 	}, Error);

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ test('reqFrom()', t => {
 	t.is(moduleNotFoundError.message, 'Cannot find module \'./nonexistent\'');
 });
 
-test('reqFrom().silent', t => {
+test('reqFrom.silent()', t => {
 	t.is(m.silent('fixture', './fixture'), 'unicorn');
 	t.is(m.silent('fixture', './nonexistent'), null);
 });

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ test('reqFrom', t => {
 	t.is(moduleNotFoundError.message, 'Cannot find module \'./nonexistent\'');
 });
 
-test('reqFrom,silent', t => {
+test('reqFrom.silent', t => {
 	t.is(fn.silent('fixture', './fixture'), 'unicorn');
 	t.is(fn.silent('fixture', './nonexistent'), null);
 });

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import fn from './';
 
-test(t => {
+test('reqFrom', t => {
 	t.is(fn('fixture', './fixture'), 'unicorn');
 	t.throws(() => fn('fixture', './nonexistent'));
 	const moduleNotFoundError = t.throws(() => {
@@ -9,6 +9,11 @@ test(t => {
 	}, Error);
 	t.is(moduleNotFoundError.code, 'MODULE_NOT_FOUND');
 	t.is(moduleNotFoundError.message, 'Cannot find module \'./nonexistent\'');
+	t.is(fn.silent('fixture', './fixture'), 'unicorn');
+	t.is(fn.silent('fixture', './nonexistent'), null);
+});
+
+test('reqFrom,silent', t => {
 	t.is(fn.silent('fixture', './fixture'), 'unicorn');
 	t.is(fn.silent('fixture', './nonexistent'), null);
 });

--- a/test.js
+++ b/test.js
@@ -1,17 +1,17 @@
 import test from 'ava';
-import fn from './';
+import m from './';
 
-test('reqFrom', t => {
-	t.is(fn('fixture', './fixture'), 'unicorn');
-	t.throws(() => fn('fixture', './nonexistent'));
+test('reqFrom()', t => {
+	t.is(m('fixture', './fixture'), 'unicorn');
+	t.throws(() => m('fixture', './nonexistent'));
 	const moduleNotFoundError = t.throws(() => {
-		fn('fixture', './nonexistent');
+		m('fixture', './nonexistent');
 	}, Error);
 	t.is(moduleNotFoundError.code, 'MODULE_NOT_FOUND');
 	t.is(moduleNotFoundError.message, 'Cannot find module \'./nonexistent\'');
 });
 
-test('reqFrom.silent', t => {
-	t.is(fn.silent('fixture', './fixture'), 'unicorn');
-	t.is(fn.silent('fixture', './nonexistent'), null);
+test('reqFrom().silent', t => {
+	t.is(m.silent('fixture', './fixture'), 'unicorn');
+	t.is(m.silent('fixture', './nonexistent'), null);
 });


### PR DESCRIPTION
If the module wasn't found, `req-from` is throwing an assertion error, this is because [resolve-from](https://github.com/sindresorhus/resolve-from) is returning `null` in case the module wasn't found.

The PR will throw a `module not found` like error, with the same code and message.

another option would be to extend `resolve-from` in order to get the original error if that's a better solution.