### PR TITLE
ES2015ify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - 'stable'
-  - '0.12'
-  - '0.10'
+  - '6'
+  - '4'

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 'use strict';
-var resolveFrom = require('resolve-from');
+const resolveFrom = require('resolve-from');
 
-module.exports = function (fromDir, moduleId) {
-	return require(resolveFrom(fromDir, moduleId));
-};
+module.exports = (fromDir, moduleId) => require(resolveFrom(fromDir, moduleId));
 
-module.exports.silent = function (fromDir, moduleId) {
+module.exports.silent = (fromDir, moduleId) => {
 	try {
 		return require(resolveFrom(fromDir, moduleId));
 	} catch (err) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava"
@@ -24,8 +24,7 @@
     "path",
     "module",
     "from",
-    "like",
-    "path"
+    "like"
   ],
   "dependencies": {
     "resolve-from": "^2.0.0"


### PR DESCRIPTION
Because of an issue with older XO versions I just decided to ES2015ify the module. Maybe I should ES2015ify `resolve-from` first so we can release that as `3.0.0` and upgrade it directly in this PR. Just let me know.